### PR TITLE
バリデーション仕様課題2.5を実施する

### DIFF
--- a/src/main/java/com/validationtask/task2/ProductRequest.java
+++ b/src/main/java/com/validationtask/task2/ProductRequest.java
@@ -16,10 +16,14 @@ public class ProductRequest {
     @Max(value = 1000000, message = "{E0005}")
     private Integer price;
 
-    public ProductRequest(String productName, String category, Integer price) {
+    @ValidSeller
+    private String seller;
+
+    public ProductRequest(String productName, String category, Integer price, String seller) {
         this.productName = productName;
         this.category = category;
         this.price = price;
+        this.seller = seller;
     }
 
     public String getProductName() {
@@ -32,5 +36,9 @@ public class ProductRequest {
 
     public Integer getPrice() {
         return price;
+    }
+
+    public String getSeller() {
+        return seller;
     }
 }

--- a/src/main/java/com/validationtask/task2/ValidSeller.java
+++ b/src/main/java/com/validationtask/task2/ValidSeller.java
@@ -1,0 +1,24 @@
+package com.validationtask.task2;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@ReportAsSingleViolation
+@NotBlank
+@Size(min = 2, max = 20)
+public @interface ValidSeller {
+    public String message() default "{ValidSeller}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -10,3 +10,5 @@ E0004=0より大きい値である必要があります
 E0005={value}以下である必要があります
 #ValidCategory
 ValidCategory=無効なカテゴリです
+#ValidSeller
+ValidSeller=無効な販売者です

--- a/src/test/java/com/validationtask/task2/ProductControllerTest.java
+++ b/src/test/java/com/validationtask/task2/ProductControllerTest.java
@@ -21,8 +21,8 @@ public class ProductControllerTest {
     MockMvc mockMvc;
 
     @Test
-    public void productNameとcategoryが空白でpriceが0の場合は400エラーとなること() throws Exception {
-        ProductRequest productRequest = new ProductRequest("", "", 0);
+    public void productNameとcategoryとsellerが空白でpriceが0の場合は400エラーとなること() throws Exception {
+        ProductRequest productRequest = new ProductRequest("", "", 0, "");
         ResultActions actual = mockMvc.perform(post("/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(productRequest)));
@@ -51,6 +51,10 @@ public class ProductControllerTest {
                               {
                                  "field": "price",
                                  "message": "0より大きい値である必要があります"
+                              },
+                              {
+                                 "field": "seller",
+                                 "message": "無効な販売者です"
                               }
                            ]
                         }
@@ -58,8 +62,8 @@ public class ProductControllerTest {
     }
 
     @Test
-    public void productNameとcategoryとpriceがnullの場合は400エラーとなること() throws Exception {
-        ProductRequest productRequest = new ProductRequest(null, null, null);
+    public void productNameとcategoryとpriceとsellerがnullの場合は400エラーとなること() throws Exception {
+        ProductRequest productRequest = new ProductRequest(null, null, null, null);
         ResultActions actual = mockMvc.perform(post("/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(productRequest)));
@@ -80,6 +84,10 @@ public class ProductControllerTest {
                               {
                                  "field": "price",
                                  "message": "入力してください"
+                              },
+                              {
+                                 "field": "seller",
+                                 "message": "無効な販売者です"
                               }
                            ]
                         }
@@ -87,8 +95,8 @@ public class ProductControllerTest {
     }
 
     @Test
-    public void productNameとcategoryとpriceが有効な場合は400エラーとならないこと() throws Exception {
-        ProductRequest productRequest = new ProductRequest("iphone15", "Electronics", 150000);
+    public void productNameとcategoryとpriceとsellerが有効な場合は400エラーとならないこと() throws Exception {
+        ProductRequest productRequest = new ProductRequest("iphone15", "Electronics", 150000, "Yamada");
         ResultActions actual = mockMvc.perform(post("/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(OBJECT_MAPPER.writeValueAsString(productRequest)));

--- a/src/test/java/com/validationtask/task2/ProductRequestTest.java
+++ b/src/test/java/com/validationtask/task2/ProductRequestTest.java
@@ -25,29 +25,29 @@ public class ProductRequestTest {
 
     @ParameterizedTest
     @CsvSource({
-            "2, Electronics, 150000",
-            "10, Electronics, 150000",
-            "20, Electronics, 150000",
-            "20, ELECTRONICS, 150000",
-            "20, electronics, 150000",
-            "20, CLOTHING, 150000",
-            "20, Clothing, 150000",
-            "20, clothing, 150000",
-            "20, BOOKS, 150000",
-            "20, Books, 150000",
-            "20, books, 150000",
-            "20, Electronics, 1",
-            "20, Electronics, 1000000"
+            "2, Electronics, 150000, 2",
+            "10, Electronics, 150000, 10",
+            "20, Electronics, 150000, 20",
+            "20, ELECTRONICS, 150000, 20",
+            "20, electronics, 150000, 20",
+            "20, CLOTHING, 150000, 20",
+            "20, Clothing, 150000, 20",
+            "20, clothing, 150000, 20",
+            "20, BOOKS, 150000, 20",
+            "20, Books, 150000, 20",
+            "20, books, 150000, 20",
+            "20, Electronics, 1, 20",
+            "20, Electronics, 1000000, 20"
     })
-    public void 有効なproductNameとcategoryとprice場合はバリデーションエラーとならないこと(String productNameCount, String category, String price) {
-        ProductRequest productRequest = new ProductRequest("p".repeat(Integer.valueOf(productNameCount)), category, Integer.valueOf(price));
+    public void 有効なproductNameとcategoryとprice場合はバリデーションエラーとならないこと(String productNameCount, String category, String price, String sellerCount) {
+        ProductRequest productRequest = new ProductRequest("p".repeat(Integer.valueOf(productNameCount)), category, Integer.valueOf(price), "Y".repeat(Integer.valueOf(sellerCount)));
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).isEmpty();
     }
 
     @Test
     public void productNameがnullのときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest(null, "Electronics", 150000);
+        ProductRequest productRequest = new ProductRequest(null, "Electronics", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -57,7 +57,7 @@ public class ProductRequestTest {
 
     @Test
     public void productNameが空文字のときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("", "Electronics", 150000);
+        ProductRequest productRequest = new ProductRequest("", "Electronics", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(2);
         assertThat(violations)
@@ -68,7 +68,7 @@ public class ProductRequestTest {
 
     @Test
     public void productNameが半角スペースのときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest(" ", "Electronics", 150000);
+        ProductRequest productRequest = new ProductRequest(" ", "Electronics", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(2);
         assertThat(violations)
@@ -79,7 +79,7 @@ public class ProductRequestTest {
 
     @Test
     public void productNameが2文字未満のときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("p", "Electronics", 150000);
+        ProductRequest productRequest = new ProductRequest("p", "Electronics", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -89,7 +89,7 @@ public class ProductRequestTest {
 
     @Test
     public void productNameが20文字超えのときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("p".repeat(21), "Electronics", 150000);
+        ProductRequest productRequest = new ProductRequest("p".repeat(21), "Electronics", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -99,7 +99,7 @@ public class ProductRequestTest {
 
     @Test
     public void categoryがnullのときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("iPhone15", null, 150000);
+        ProductRequest productRequest = new ProductRequest("iPhone15", null, 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -109,7 +109,7 @@ public class ProductRequestTest {
 
     @Test
     public void categoryが空白のときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("iPhone15", "", 150000);
+        ProductRequest productRequest = new ProductRequest("iPhone15", "", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(2);
         assertThat(violations)
@@ -120,7 +120,7 @@ public class ProductRequestTest {
 
     @Test
     public void categoryが半角スペースのときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("iPhone15", " ", 150000);
+        ProductRequest productRequest = new ProductRequest("iPhone15", " ", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(2);
         assertThat(violations)
@@ -131,7 +131,7 @@ public class ProductRequestTest {
 
     @Test
     public void categoryがElectronicsとClothingとBooks以外のときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("Table", "Furniture", 150000);
+        ProductRequest productRequest = new ProductRequest("Table", "Furniture", 150000, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -141,7 +141,7 @@ public class ProductRequestTest {
 
     @Test
     public void priceがnullのときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", null);
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", null, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -151,7 +151,7 @@ public class ProductRequestTest {
 
     @Test
     public void priceが0以下のときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 0);
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 0, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -161,11 +161,92 @@ public class ProductRequestTest {
 
     @Test
     public void priceが1000000超えのときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 1000001);
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 1000001, "Yamada");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
                 .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
                 .containsExactlyInAnyOrder(tuple("price", "1000000以下である必要があります"));
+    }
+
+    @Test
+    public void sellerがnullのときにバリデーションエラーとなること() {
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, null);
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("seller", "無効な販売者です"));
+    }
+
+    @Test
+    public void sellerが空文字のときにバリデーションエラーとなること() {
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, "");
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("seller", "無効な販売者です"));
+    }
+
+    @Test
+    public void sellerが半角スペースのときにバリデーションエラーとなること() {
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, " ");
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("seller", "無効な販売者です"));
+    }
+
+    @Test
+    public void sellerが2文字未満のときにバリデーションエラーとなること() {
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, "Y".repeat(1));
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("seller", "無効な販売者です"));
+    }
+
+    @Test
+    public void sellerが20文字超えのときにバリデーションエラーとなること() {
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, "Y".repeat(21));
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("seller", "無効な販売者です"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "20, Electronics, 1000000, \uD868\uDC82",
+            "20, Electronics, 1000000, 📷"
+    })
+    public void sellerに1文字のサロゲートペアの漢字と絵文字を渡したときにバリデーションエラーとならないこと(String productNameCount, String category, String price, String sellerCount) {
+        ProductRequest productRequest = new ProductRequest("p".repeat(Integer.valueOf(productNameCount)), category, Integer.valueOf(price), sellerCount);
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void sellerが19文字の通常文字と1文字のサロゲートペアの漢字を渡したときにバリデーションエラーとなること() {
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, "Y".repeat(19) + "\uD868\uDC82");
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("seller", "無効な販売者です"));
+    }
+
+    @Test
+    public void sellerが19文字の通常文字と絵文字を渡したときにバリデーションエラーとなること() {
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, "Y".repeat(19) + "📷");
+        Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(tuple("seller", "無効な販売者です"));
     }
 }

--- a/src/test/java/com/validationtask/task2/ProductRequestTest.java
+++ b/src/test/java/com/validationtask/task2/ProductRequestTest.java
@@ -221,7 +221,7 @@ public class ProductRequestTest {
 
     @ParameterizedTest
     @CsvSource({
-            "20, Electronics, 1000000, \uD868\uDC82",
+            "20, Electronics, 1000000, 𪂂",
             "20, Electronics, 1000000, 📷"
     })
     public void sellerに1文字のサロゲートペアの漢字と絵文字を渡したときにバリデーションエラーとならないこと(String productNameCount, String category, String price, String sellerCount) {
@@ -232,7 +232,7 @@ public class ProductRequestTest {
 
     @Test
     public void sellerが19文字の通常文字と1文字のサロゲートペアの漢字を渡したときにバリデーションエラーとなること() {
-        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, "Y".repeat(19) + "\uD868\uDC82");
+        ProductRequest productRequest = new ProductRequest("iPhone15", "Electronics", 150000, "Y".repeat(19) + "𪂂");
         Set<ConstraintViolation<ProductRequest>> violations = validator.validate(productRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)


### PR DESCRIPTION
### やったこと

- ProductRequestにsellerの追加とValidSellerアノテーションの作成をやるました。
- ProductRequestTestにてsellerに1文字のサロゲートペアの漢字と絵文字を渡した時にそれぞれバリデーションエラーとならないことを確認しました。
- ProductRequestTestにてsellerに19文字の通常文字と1文字のサロゲートペアの漢字、絵文字を渡した時にそれぞれバリデーションエラーとなることを確認しました。

バリデーション課題2.5のリンク - https://github.com/reytech-co-jp/validation-tutorial/tree/feature/add_task2.5#課題25